### PR TITLE
[stable/2024.1] snap: Removes dangling symlinks

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,6 +36,11 @@ parts:
     stage-packages:
       - manila-data
       - ceph-common
+    override-build: |
+      craftctl default
+      # purge some dangling symlinks
+      rm -rf $CRAFT_PART_INSTALL/usr/lib/python3/dist-packages/netaddr/eui/iab.txt
+      rm -rf $CRAFT_PART_INSTALL/usr/lib/python3/dist-packages/netaddr/eui/oui.txt
     organize:
       usr/bin/: bin/
       usr/sbin/: bin/


### PR DESCRIPTION
# Description

The snap contains some external dangling symlinks, which have to be removed.

(cherry picked from commit 2b3da04e7d594bd4df70d278b4bd30b5b0a79675)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
