### PR TITLE
[stable/2024.1] snap: Update snap to 2024.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,18 +1,12 @@
 name: manila-data
 base: core24
-version: "2025.1"
+version: "2024.1"
 summary: manila-data in a snap
 description: |
   Manila is the OpenStack project that provides shared filesystems as a
   service for instances. This snap provides the manila-data service.
 
 confinement: strict
-
-package-repositories:
-  - type: apt
-    cloud: epoxy
-    priority: always
-    pocket: proposed
 
 environment:
   PYTHONPATH: $SNAP/lib/python3.12:$SNAP/lib/python3.12/site-packages:$SNAP/lib/python3.12/dist-packages:$PYTHONPATH


### PR DESCRIPTION
# Description

The epoxy repository contains the OpenStack 2025.1 packages, while Ubuntu 24.04 repositories have the 2024.1 packages by default. [1]

[1] https://docs.openstack.org/install-guide/environment-packages-ubuntu.html

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
