### PR TITLE
tics: add prerequisite packages

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -28,6 +28,7 @@ jobs:
           run: |
             uv sync --all-extras
             source .venv/bin/activate
+            echo PATH=$PATH >> $GITHUB_ENV
 
         - name: TICS
           uses: tiobe/tics-github-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
   "mypy",
   "coverage",
 ]
+tics = ["pylint", "flake8"]
 
 [build-system]
 requires = ["setuptools", "setuptools-scm"]


### PR DESCRIPTION
Add packages required for tics in pyporject.toml
Pass PATH env to GITHUB_PATH so that uv venv is
considered in tics execution

